### PR TITLE
Set dependency of lto to 1.0.*

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [metadata]
 name = lto-cli
 version = 0.0.0
-author = Andrea
-author_email = andrea@ltonetwork.com
-description = LTO Network CLI Client
+author = LTO Network
+author_email = info@ltonetwork.com
+description = LTO Network CLI
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/ltonetwork/lto-cli
@@ -20,7 +20,7 @@ package_dir =
 packages = find:
 python_requires = >=3.6
 install_requires =
-    lto==1.0
+    lto==1.0.*
     argparse
     configparser
     pathlib


### PR DESCRIPTION
```
ERROR: lto-cli 1.0.0 has requirement lto==1.0, but you'll have lto 1.0.1 which is incompatible.
```

Also, set LTO Network as author