### PR TITLE
More secure way to provide the seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ lto [command] --help
 
 ```
 lto account create
-echo "my seed" | lto account seed
+read -s -p "Enter seed: " seed && echo $seed | lto account seed
 lto account list
 lto account set-default foobar
 lto account remove 3JuijVBB7NCwCz2Ae5HhCDsqCXzeBLRTyeL

--- a/src/lto_cli/cli.py
+++ b/src/lto_cli/cli.py
@@ -102,7 +102,7 @@ def main():
     parser_show.add_argument('--testnet', '-T', action='store_const', dest='network', const='T', required=False, help='Short for --network=T')
 
     parser_seed = account_subparser.add_parser('seed', help="Create an account from seed, for more information on how to pipe the seed type 'lto account seed --help")
-    parser_seed.add_argument('stdin', nargs='?', type=argparse.FileType('r'), default=sys.stdin, help="Takes the seeds as input: echo 'my seed' | lto account seed")
+    parser_seed.add_argument('stdin', nargs='?', type=argparse.FileType('r'), default=sys.stdin, help="Takes the seeds as input: read -s -p 'Enter seed: ' seed && echo $seed | lto account seed")
     parser_seed.add_argument('--name', required=False, type=str, nargs=1)
     parser_seed.add_argument('--network', type=str, nargs=1, required=False, help ='Optional network parameter, if not specified default is L')
     parser_seed.add_argument('--testnet', '-T', action='store_const', dest='network', const='T', required=False, help='Short for --network=T')

--- a/src/lto_cli/cli.py
+++ b/src/lto_cli/cli.py
@@ -101,7 +101,7 @@ def main():
     parser_show.add_argument('--network', type=str, nargs=1, required=False, help='Optional network parameter, if not specified default is L')
     parser_show.add_argument('--testnet', '-T', action='store_const', dest='network', const='T', required=False, help='Short for --network=T')
 
-    parser_seed = account_subparser.add_parser('seed', help="Create an account from seed, for more information on how to pipe the seed type 'lto account seed --help")
+    parser_seed = account_subparser.add_parser('seed', help="Create an account from seed, for more information on how to pipe the seed type 'lto account seed --help'")
     parser_seed.add_argument('stdin', nargs='?', type=argparse.FileType('r'), default=sys.stdin, help="Takes the seeds as input: read -s -p 'Enter seed: ' seed && echo $seed | lto account seed")
     parser_seed.add_argument('--name', required=False, type=str, nargs=1)
     parser_seed.add_argument('--network', type=str, nargs=1, required=False, help ='Optional network parameter, if not specified default is L')


### PR DESCRIPTION
Changed the instructions and examples on how to use the "import seed" feature using `lto account seed`.

Current way: Input the seed plain text on the CLI and pipe to lto cli. Commands tend to be logged and could potentially leak.
New way: Prompt for seed phrase and pipe to lto cli. Seed won't end up in command logs.
